### PR TITLE
Prefer `Time` to `DateTime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,10 @@ your application.
   Time.current # Same thing but shorter.
   ```
 
++* <a name="prefer-time-to-datetime"></a>
++  Prefer `Time` to `DateTime`, unless you need to deal with dates and times in a [historical context](https://gist.github.com/pixeltrix/e2298822dd89d854444b).
++<sup>[[link](#prefer-time-to-datetime)]</sup>
+
 ## Bundler
 
 * <a name="dev-test-gems"></a>


### PR DESCRIPTION
The linked gist is by a Rails core member, so I think it can be treated as being on good authority.