### PR TITLE
Use Heredocs for multiline SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,33 @@ when you need to retrieve a single record by some attributes.
   # good
   User.where.not(id: id)
   ```
+* <a name="squished-heredocs"></a>
+  When specifying an explicit query in a method such as `find_by_sql`, use
+  heredocs with `squish`. This allows you to legibly format the SQL with
+  line breaks and indentations, while supporting syntax highlighting in many
+  tools (including GitHub, Atom, and RubyMine).
+<sup>[[link](#squished-heredocs)]</sup>
+
+  ```Ruby
+  User.find_by_sql(<<SQL.squish)
+    SELECT
+      users.id, accounts.plan
+    FROM
+      users
+    INNER JOIN
+      accounts
+    ON
+      accounts.user_id = users.id
+    # further complexities...
+  SQL
+  ```
+
+  [`String#squish`](http://apidock.com/rails/String/squish) removes the indentation and newline characters so that your server
+  log shows a fluid string of SQL rather than something like this:
+
+  ```
+  SELECT\n    users.id, accounts.plan\n  FROM\n    users\n  INNER JOIN\n    acounts\n  ON\n    accounts.user_id = users.id
+  ```
 
 ## Migrations
 


### PR DESCRIPTION
I didn't see anything in this guide covering the format of multiline SQL strings used with methods like `find_by_sql` or `ActiveRecord::Base.connection.execute`. I know the preferred approach is to use ActiveRecord helpers, but as even the Rails guides themselves [admit](http://guides.rubyonrails.org/active_record_migrations.html#when-helpers-aren-t-enough), this isn't always sufficient. As such, I decided to include the practice we currently follow at OneLogin.

The content I added is pretty self-explanatory, but we use heredocs because they're [recommended](https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand) for multiline strings and enable SQL syntax highlighting in many tools. Because the indentations and line breaks are only meant for readers of the source, the heredoc is immediately followed by ``squish`` to suppress any extra characters in server logs.