### PR TITLE
Add a note about shallow routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ programming resources.
     resources :comments
   end
   ```
+  
+* <a name="namespaced-routes"></a>
+  If you need to nest routes more than 1 level deep then use the `shallow: true` option. This will save user from long urls `posts/1/comments/5/versions/7/edit` and you from long url helpers `edit_post_comment_version`.
+  
+  ```Ruby
+  resources :posts, shallow: true do
+    resources :comments do
+      resources :versions
+    end
+  end
+  ```
 
 * <a name="namespaced-routes"></a>
   Use namespaced routes to group related actions.


### PR DESCRIPTION
Add info about using shallow routes for nested routes more than 1 level deep.
This seems to be reasonable in order to avoid long urls for users (especially in case of long resource names like "payment_notification", "scheduled_appointment", etc.) and long url helpers for devs.