### PR TITLE
Use the new hash syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,7 +831,7 @@ when you need to retrieve a single record by some attributes.
 
   ```Ruby
   # bad
-  I18n.t :record_invalid, :scope => [:activerecord, :errors, :messages]
+  I18n.t :record_invalid, scope: [:activerecord, :errors, :messages]
 
   # good
   I18n.t 'activerecord.errors.messages.record_invalid'


### PR DESCRIPTION
Although this sample is under a "bad" code snippet, the thing to avoid is about something entirely different (i18n scoping), so I don't think we should use the older hash syntax anyway.