### PR TITLE
Added enum macro recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,10 @@ programming resources.
     attr_accessor :formatted_date_of_birth
 
     attr_accessible :login, :first_name, :last_name, :email, :password
-
+    
+    # Rails4+ enums after attr macros, prefer the hash syntax
+    enum gender: { female: 0, male: 1 }
+    
     # followed by association macros
     belongs_to :country
 


### PR DESCRIPTION
Enums are a meaningful addition to Rails model ecosystem and can be used in the majority of models where a field can take a limited selection of values, but bool is insufficient.

Placing their definition under attr macros is one way to go about it, another might be to put them above attr macros, right under constants.
I'd be glad to hear others' opinion on the matter.