### PR TITLE
Add the dependent option to the Active Record associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,22 @@ programming resources.
   end
   ```
 
+* <a name="has_many-has_one-dependent-option"></a>
+  Define the `dependent` option to the `has_many` and `has_one` associations.
+<sup>[[link](#has_many-has_one-dependent-option)]</sup>
+
+  ```Ruby
+  # bad
+  class Post < ActiveRecord::Base
+    has_many :comments
+  end
+
+  # good
+  class Post < ActiveRecord::Base
+    has_many :comments, dependent: :destroy
+  end
+  ```
+
 ### ActiveRecord Queries
 
 * <a name="avoid-interpolation"></a>


### PR DESCRIPTION
Hi guys,

When we have a has many association without the `dependent` option like Chat
has many messages and we destroy the Chat, the Message objects still have the
`chat_id` reference pointing to a Chat that was destroyed.

```
[1] pry(main)> chat = Chat.first
                 :id => 1,
               :name => "Chat 01"
}
[2] pry(main)> message = chat.messages.first
            :id => 1,
       :message => "message 1",
       :chat_id => 1,
}
[3] pry(main)> chat.destroy
[4] pry(main)> message.reload
            :id => 1,
       :message => "message 1",
       :chat_id => 1,
}
[5] pry(main)> message.chat_id
1
[6] pry(main)> message.chat
nil
```

This patch add the `dependent` option to the has many and has one associations
to keep the things more explicit.

Thanks