### PR TITLE
Add ActiveSupport section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ programming resources.
 * [Internationalization](#internationalization)
 * [Assets](#assets)
 * [Mailers](#mailers)
+* [Active Support Core Extensions](#active-support-core-extensions)
 * [Time](#time)
 * [Bundler](#bundler)
 * [Managing processes](#managing-processes)
@@ -985,6 +986,22 @@ your application.
   sent. To overcome this emails can be sent in background process with the help
   of [sidekiq](https://github.com/mperham/sidekiq) gem.
 <sup>[[link](#background-email)]</sup>
+
+
+## Active Support Core Extensions
+
+* <a name="try-bang"></a>
+  Prefer Ruby 2.3.0's safe navigation operator `&.` over `ActiveSupport#try!`.
+<sup>[[link](#try-bang)]</sup>
+
+```ruby
+# bad
+obj.try! :fly
+
+# good
+obj&.fly
+```
+
 
 ## Time
 

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,21 @@ obj.try! :fly
 obj&.fly
 ```
 
+* <a name="active_support_aliases"></a>
+  Prefer Ruby's Standard Library methods over `ActiveSupport` aliases.
+<sup>[[link](#active_support_aliases)]</sup>
+
+```ruby
+# bad
+'the day'.starts_with? 'th'
+'the day'.ends_with? 'ay'
+
+# good
+'the day'.start_with? 'th'
+'the day'.end_with? 'ay'
+```
+
+
 
 ## Time
 

--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,21 @@ obj&.fly
 'the day'.end_with? 'ay'
 ```
 
+* <a name="active_support_extensions"></a>
+  Prefer Ruby's Standard Library over uncommon ActiveSupport extensions.`
+<sup>[[link](#active_support_extensions)]</sup>
+
+```ruby
+# bad
+(1..50).to_a.forty_two
+1.in? [1, 2]
+'day'.in? 'the day'
+
+# good
+(1..50).to_a[41]
+[1, 2].include? 1
+'the day'.include? 'day'
+```
 
 
 ## Time

--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,35 @@ obj&.fly
 'the day'.include? 'day'
 ```
 
+* <a name="inquiry"></a>
+  Prefer Ruby's comparison operators over ActiveSupport's `Array#inquiry`, `Numeric#inquiry` and `String#inquiry`.
+<sup>[[link](#inquiry)]</sup>
+
+```ruby
+# bad - String#inquiry
+ruby = 'two'.inquiry
+ruby.two?
+
+# good
+ruby = 'two'
+ruby == 'two'
+
+# bad - Array#inquiry
+pets = %w(cat dog).inquiry
+pets.gopher?
+
+# good
+pets = %w(cat dog).inquiry
+pets.include? 'cat'
+
+# bad - Numeric#inquiry
+0.positive?
+0.negative?
+
+# good
+0 > 0
+0 < 0
+```
 
 ## Time
 


### PR DESCRIPTION
## Motivation:

Depend as little as possible on `ActiveSupport`.


## Change: 

Added tips about usage of `ActiveSupport` extensions:

* `try!`,
* `starts_with`,
* `ends_with`,
* `in?`,
* `forty_two`,
* `inquiry`

