### PR TITLE
Transpose Examples in #sexy-validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,11 +442,11 @@ render plain: 'Ruby!'
 
   ```Ruby
   # bad
-  validates_presence_of :email
-  validates_length_of :email, maximum: 100
+  validates :email, presence: true, length: { maximum: 100 }
 
   # good
-  validates :email, presence: true, length: { maximum: 100 }
+  validates_presence_of :email
+  validates_length_of :email, maximum: 100
   ```
 
 * <a name="custom-validator-file"></a>


### PR DESCRIPTION
The rule says to 'always use the new "sexy" validations', but the examples suggest "sexy" validations are bad.

We think "sexy" validations are good: they're easier to read.

The examples have been this way since inception w/ 60ca12c.