### PR TITLE
Remove duplicated advice for find_each method using.

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,23 +683,6 @@ when you need to retrieve a single record by some attributes.
   User.find_by(first_name: 'Bruce', last_name: 'Wayne')
   ```
 
-* <a name="find_each"></a>
-  Use `find_each` when you need to process a lot of records.
-<sup>[[link](#find_each)]</sup>
-
-  ```Ruby
-  # bad - loads all the records at once
-  # This is very inefficient when the users table has thousands of rows.
-  User.all.each do |user|
-    NewsMailer.weekly(user).deliver_now
-  end
-
-  # good - records are retrieved in batches
-  User.find_each do |user|
-    NewsMailer.weekly(user).deliver_now
-  end
-  ```
-
 * <a name="where-not"></a>
   Favor the use of `where.not` over SQL.
 <sup>[[link](#where-not)]</sup>


### PR DESCRIPTION
Hello, Bozhidar!

Thanks for your gold mine of good advices.

Reading the style guides, I found advice that match twice ([one](https://github.com/bbatsov/rails-style-guide#find-each), [another one](https://github.com/bbatsov/rails-style-guide#find_each)) in the text (it seems to me):

So I found it necessary to remove the repetition.

Am I wrong? :)

Thanks.