### PR TITLE
Use symbols instead of numeric status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,22 @@ render plain: 'Ruby!'
 ...
 ```
 
+* <a name="http-status-code-symbols"></a>
+  Prefer [corresponding symbols](https://gist.github.com/mlanett/a31c340b132ddefa9cca) to numeric HTTP status codes. They are meaningful and do not look like "magic" numbers for less known HTTP status codes.
+<sup>[[link](#http-status-code-symbols)]</sup>
+
+```Ruby
+# bad
+...
+render status: 500
+...
+
+# good
+...
+render status: :forbidden
+...
+```
+
 ## Models
 
 * <a name="model-classes"></a>


### PR DESCRIPTION
Rails has [symbols](http://billpatrianakos.me/blog/2013/10/13/list-of-rails-status-code-symbols/) for status codes. Why don't we use them by default? It would make more sense to the code.