### PR TITLE
Use `find_by` instead of `find` to retrieve a single record by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ render status: :forbidden
   ```
 
 * <a name="find"></a>
-  Favor the use of `find` over `where`
+  Favor the use of `find_by` over `where`
 when you need to retrieve a single record by id.
 <sup>[[link](#find)]</sup>
 
@@ -694,7 +694,7 @@ when you need to retrieve a single record by id.
   User.where(id: id).take
 
   # good
-  User.find(id)
+  User.find_by(id: id)
   ```
 
 * <a name="find_by"></a>


### PR DESCRIPTION
WHY
---

ref. https://github.com/bbatsov/rails-style-guide/issues/76#issuecomment-156909719
`ActiveRecord::FinderMethods#find` will raise `ActiveRecord::RecordNotFound` exception when we cannot retrieve the record by id. However, `ActiveRecord::FinderMethods#take` with `where` won't raise error if no record is found. So we should use `find_by` instead of `find`.
```rb
User.find(id)
# If no record is found, it raises ActiveRecord::RecordNotFound exception.

User.find_by(id: id)
# If no record is found, it returns nil.
```