### PR TITLE
Add Rails 4 Test Prescriptions book reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,7 @@ you have time to spare:
 * [The RSpec Book](http://pragprog.com/book/achbd/the-rspec-book)
 * [The Cucumber Book](http://pragprog.com/book/hwcuc/the-cucumber-book)
 * [Everyday Rails Testing with RSpec](https://leanpub.com/everydayrailsrspec)
+* [Rails 4 Test Prescriptions](https://pragprog.com/book/nrtest2/rails-4-test-prescriptions)
 * [Better Specs for RSpec](http://betterspecs.org)
 
 # Contributing


### PR DESCRIPTION
 This book belongs in the "Further Reading" section as an equal of the other choices.