### PR TITLE
Change column default value by more appropriate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ when you need to retrieve a single record by some attributes.
   # good - database enforced
   class AddDefaultAmountToProducts < ActiveRecord::Migration
     def change
-      change_column :products, :amount, :integer, default: 0
+      change_column_default :products, :amount, 0
     end
   end
   ```


### PR DESCRIPTION
**change_column_default** method has self-descriptive name and it's usage is safer that change_column which is potentially danger (for example accidental column type change is possible).

One more advantage is that this method can be reversible in Rails 5 by specifying **from** & **to** parameter - [PR20018](https://github.com/rails/rails/pull/20018/files)