### PR TITLE
Remove Numeric#inquiry as bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -1303,7 +1303,7 @@ obj&.fly
 ```
 
 * <a name="inquiry"></a>
-  Prefer Ruby's comparison operators over ActiveSupport's `Array#inquiry`, `Numeric#inquiry` and `String#inquiry`.
+  Prefer Ruby's comparison operators over ActiveSupport's `Array#inquiry`, and `String#inquiry`.
 <sup>[[link](#inquiry)]</sup>
 
 ```ruby
@@ -1322,14 +1322,6 @@ pets.gopher?
 # good
 pets = %w(cat dog)
 pets.include? 'cat'
-
-# bad - Numeric#inquiry
-0.positive?
-0.negative?
-
-# good
-0 > 0
-0 < 0
 ```
 
 ## Time


### PR DESCRIPTION
This has been upstreamed in Ruby 2.3: https://ruby-doc.org/core-2.3.0/Numeric.html#method-i-negative-3F

It also allows writing `(-2..2).select(&:positive?)` instead of `(-2..2).select { |i| i > 0 }` which is in line with https://github.com/bbatsov/ruby-style-guide#single-action-blocks